### PR TITLE
render html tags in doc comments as code

### DIFF
--- a/malvolio/src/macros.rs
+++ b/malvolio/src/macros.rs
@@ -19,7 +19,7 @@ macro_rules! heading_display {
                 f.write_str("<")?;
                 f.write_str(stringify!($name))?;
                 f.write_str(" ")?;
-                crate::utils::write_attributes(&self.attrs, f)?;
+                $crate::utils::write_attributes(&self.attrs, f)?;
                 f.write_str(">")?;
                 self.text.fmt(f)?;
                 f.write_str("</")?;
@@ -41,8 +41,8 @@ macro_rules! impl_of_heading_mutator {
                 fuzzcheck::mutators::map::MapMutator::new(
                     fuzzcheck::mutators::tuples::TupleMutatorWrapper::new(
                         fuzzcheck::mutators::tuples::Tuple2Mutator::new(
-                            crate::mutators::valid_attr_string_mutator::<0>(),
-                            crate::mutators::attr_mutator(),
+                            $crate::mutators::valid_attr_string_mutator::<0>(),
+                            $crate::mutators::attr_mutator(),
                         ),
                     ),
                     |h1: &$name| Some((h1.text.to_string(), h1.attrs.clone())),
@@ -114,7 +114,7 @@ macro_rules! impl_of_heading_new_fn {
                 self
             }
 
-            crate::define_raw_attribute_fn!();
+            $crate::define_raw_attribute_fn!();
 
             /// Read an attribute that has been set.
             pub fn read_attribute(

--- a/malvolio/src/tags/body/body_node.rs
+++ b/malvolio/src/tags/body/body_node.rs
@@ -24,7 +24,7 @@ use crate::{
 utility_enum!(
     #[allow(missing_docs)]
     #[cfg_attr(feature = "fuzz", derive(serde::Serialize, serde::Deserialize))]
-    /// A node which can be mounted to the <body> tag (or any of its children).
+    /// A node which can be mounted to the `<body>` tag (or any of its children).
     pub enum BodyNode {
         H1(H1),
         H2(H2),

--- a/malvolio/src/tags/body/mod.rs
+++ b/malvolio/src/tags/body/mod.rs
@@ -16,7 +16,7 @@ pub mod body_node;
 #[derivative(Default(new = "true"))]
 #[cfg_attr(feature = "pub_fields", derive(FieldsAccessibleVariant))]
 #[cfg_attr(feature = "fuzz", derive(serde::Serialize, serde::Deserialize))]
-/// The <body> tag.
+/// The `<body>` tag.
 #[must_use]
 pub struct Body {
     children: Vec<BodyNode>,

--- a/malvolio/src/tags/head/head_node.rs
+++ b/malvolio/src/tags/head/head_node.rs
@@ -11,7 +11,7 @@ use crate::{
 utility_enum!(
     #[cfg_attr(feature = "fuzz", derive(serde::Serialize, serde::Deserialize))]
     #[allow(missing_docs)]
-    /// A node which can be attached to the <head> tag.
+    /// A node which can be attached to the `<head>` tag.
     pub enum HeadNode {
         Title(Title),
         Meta(Meta),

--- a/malvolio/src/tags/head/mod.rs
+++ b/malvolio/src/tags/head/mod.rs
@@ -15,7 +15,7 @@ pub mod head_node;
 #[cfg_attr(feature = "pub_fields", derive(FieldsAccessibleVariant))]
 #[cfg_attr(feature = "fuzz", derive(serde::Serialize, serde::Deserialize))]
 #[must_use]
-/// The <head> tag.
+/// The `<head>` tag.
 pub struct Head {
     children: Vec<HeadNode>,
 }
@@ -44,7 +44,7 @@ pub fn head() -> Head {
 }
 
 impl Head {
-    /// Add a number of children to this <head> tag from an iterator.
+    /// Add a number of children to this `<head>` tag from an iterator.
     pub fn children<I, C>(mut self, children: I) -> Self
     where
         C: Into<HeadNode>,
@@ -54,7 +54,7 @@ impl Head {
             .extend(children.into_iter().map(Into::into).collect::<Vec<_>>());
         self
     }
-    /// Add a single child to this <head> tag.
+    /// Add a single child to this `<head>` tag.
     pub fn child<C>(mut self, child: C) -> Self
     where
         C: Into<HeadNode>,

--- a/malvolio/src/tags/headings.rs
+++ b/malvolio/src/tags/headings.rs
@@ -17,7 +17,7 @@ use super::body::body_node::BodyNode;
 #[derive(Default, Debug, Clone)]
 #[cfg_attr(feature = "pub_fields", derive(FieldsAccessibleVariant))]
 #[cfg_attr(feature = "fuzz", derive(serde::Serialize, serde::Deserialize))]
-/// The <h1> tag.
+/// The `<h1>` tag.
 ///
 /// See
 /// [MDN's page on this](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements)
@@ -39,7 +39,7 @@ heading_display!(H1);
 #[derive(Default, Debug, Clone)]
 #[cfg_attr(feature = "pub_fields", derive(FieldsAccessibleVariant))]
 #[cfg_attr(feature = "fuzz", derive(serde::Serialize, serde::Deserialize))]
-/// The <h2> tag.
+/// The `<h2>` tag.
 ///
 /// See
 /// [MDN's page on this](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements)
@@ -61,7 +61,7 @@ heading_display!(H2);
 #[derive(Default, Debug, Clone)]
 #[cfg_attr(feature = "pub_fields", derive(FieldsAccessibleVariant))]
 #[cfg_attr(feature = "fuzz", derive(serde::Serialize, serde::Deserialize))]
-/// The <h3> tag.
+/// The `<h3>` tag.
 ///
 /// See
 /// [MDN's page on this](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements)
@@ -83,7 +83,7 @@ heading_display!(H3);
 #[derive(Default, Debug, Clone)]
 #[cfg_attr(feature = "pub_fields", derive(FieldsAccessibleVariant))]
 #[cfg_attr(feature = "fuzz", derive(serde::Serialize, serde::Deserialize))]
-/// The <h4> tag.
+/// The `<h4>` tag.
 ///
 /// See
 /// [MDN's page on this](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements)
@@ -105,7 +105,7 @@ heading_display!(H4);
 #[derive(Default, Debug, Clone)]
 #[cfg_attr(feature = "pub_fields", derive(FieldsAccessibleVariant))]
 #[cfg_attr(feature = "fuzz", derive(serde::Serialize, serde::Deserialize))]
-/// The <h5> tag.
+/// The `<h5>` tag.
 ///
 /// See
 /// [MDN's page on this](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements)
@@ -127,7 +127,7 @@ heading_display!(H5);
 #[derive(Default, Debug, Clone)]
 #[cfg_attr(feature = "pub_fields", derive(FieldsAccessibleVariant))]
 #[cfg_attr(feature = "fuzz", derive(serde::Serialize, serde::Deserialize))]
-/// The <h6> tag.
+/// The `<h6>` tag.
 ///
 /// See
 /// [MDN's page on this](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements)

--- a/malvolio/src/tags/html.rs
+++ b/malvolio/src/tags/html.rs
@@ -60,13 +60,13 @@ impl Html {
         Self::default()
     }
 
-    /// Attach a <head> tag to this `Html` instance.
+    /// Attach a `<head>` tag to this `Html` instance.
     pub fn head(mut self, head: Head) -> Self {
         self.head = head;
         self
     }
 
-    /// Attach a new <body> tag to this `Html` instance.
+    /// Attach a new `<body>` tag to this `Html` instance.
     pub fn body(mut self, body: Body) -> Self {
         self.body = body;
         self

--- a/malvolio/src/tags/img.rs
+++ b/malvolio/src/tags/img.rs
@@ -64,7 +64,7 @@ impl Display for Img {
 }
 
 impl Img {
-    /// Attach an attribute to the <img> tag in question.
+    /// Attach an attribute to the `<img>` tag in question.
     pub fn attribute<A>(mut self, attribute: A) -> Self
     where
         A: Into<ImgAttr>,

--- a/malvolio/src/tags/meta.rs
+++ b/malvolio/src/tags/meta.rs
@@ -137,7 +137,7 @@ into_grouping_union!(MetaName, MetaAttr);
 
 #[derive(Debug, Clone)]
 
-/// The "content" attribute for a <meta> tag.
+/// The "content" attribute for a `<meta>` tag.
 pub struct Content(Cow<'static, str>);
 
 impl Content {

--- a/malvolio/src/tags/mod.rs
+++ b/malvolio/src/tags/mod.rs
@@ -4,38 +4,38 @@ A copy of this license can be found in the `licenses` directory at the root of t
 */
 /// Links
 pub mod a;
-/// The <body> tag.
+/// The `<body>` tag.
 pub mod body;
-/// The <br> (new line) tag.
+/// The `<br>` (new line) tag.
 pub mod br;
-/// The <div> tag.
+/// The `<div>` tag.
 pub mod div;
-/// The <form> tag.
+/// The `<form>` tag.
 pub mod form;
-/// The <head> tag.
+/// The `<head>` tag.
 pub mod head;
 /// The heading tags (h1 to h6).
 pub mod headings;
-/// The <html> tag.
+/// The `<html>` tag.
 pub mod html;
-/// The <img> tag.
+/// The `<img>` tag.
 pub mod img;
-/// The <input> tag.
+/// The `<input>` tag.
 pub mod input;
-/// The <label> tag.
+/// The `<label>` tag.
 pub mod label;
-/// The <meta> tag.
+/// The `<meta>` tag.
 pub mod meta;
-/// The <noscript> tag.
+/// The `<noscript>` tag.
 /// rendering.
 pub mod noscript;
-/// The <option> tag.
+/// The `<option>` tag.
 pub mod option;
-/// The <p> (paragraph) tag.
+/// The `<p>` (paragraph) tag.
 pub mod p;
-/// The <select> tag.
+/// The `<select>` tag.
 pub mod select;
-/// The <style> tag.
+/// The `<style>` tag.
 pub mod style;
-/// The <title> tag.
+/// The `<title>` tag.
 pub mod title;

--- a/malvolio/src/tags/noscript.rs
+++ b/malvolio/src/tags/noscript.rs
@@ -6,7 +6,7 @@ use crate::into_grouping_union;
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "pub_fields", derive(FieldsAccessibleVariant))]
 #[cfg_attr(feature = "fuzz", derive(serde::Serialize, serde::Deserialize))]
-/// The <noscript> tag. The contents of this tag will be shown to people whose browsers don't
+/// The `<noscript>` tag. The contents of this tag will be shown to people whose browsers don't
 /// support Javascript, or who don't have Javascript enabled.
 ///
 /// See [MDN's page on this](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/noscript) for
@@ -52,7 +52,7 @@ pub fn noscript(text: impl Into<Cow<'static, str>>) -> NoScript {
 }
 
 impl NoScript {
-    /// Construct a new <noscript> tag.
+    /// Construct a new `<noscript>` tag.
     pub fn new<T>(text: T) -> Self
     where
         T: Into<Cow<'static, str>>,

--- a/malvolio/src/tags/option.rs
+++ b/malvolio/src/tags/option.rs
@@ -18,7 +18,7 @@ use super::input::{Name, Value};
 #[derivative(Default(new = "true"))]
 #[cfg_attr(feature = "pub_fields", derive(FieldsAccessibleVariant))]
 #[cfg_attr(feature = "fuzz", derive(serde::Serialize, serde::Deserialize))]
-/// The `option` tag.
+/// The `<option>` tag.
 ///
 /// See [MDN's page on this](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/option) for
 /// further information.
@@ -133,7 +133,7 @@ impl Display for SelectOption {
 }
 
 utility_enum!(
-    /// An attribute for the <select> tag.
+    /// An attribute for the `<select>` tag.
     #[allow(missing_docs)]
     pub enum SelectOptionAttr {
         Value(Value),

--- a/malvolio/src/tags/p.rs
+++ b/malvolio/src/tags/p.rs
@@ -17,7 +17,7 @@ use crate::{
     utils::write_attributes,
 };
 
-/// The <p> tag.
+/// The `<p>` tag.
 ///
 /// See the [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p) for more
 /// info.

--- a/malvolio/src/tags/select.rs
+++ b/malvolio/src/tags/select.rs
@@ -20,7 +20,7 @@ use super::{body::body_node::BodyNode, input::Name, option::SelectOption};
 #[derivative(Default(new = "true"))]
 #[cfg_attr(feature = "pub_fields", derive(FieldsAccessibleVariant))]
 #[cfg_attr(feature = "fuzz", derive(serde::Serialize, serde::Deserialize))]
-/// The `select` tag.
+/// The `<select>` tag.
 ///
 /// See [MDN's page on this](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select) for
 /// further information.
@@ -80,7 +80,7 @@ pub fn select() -> Select {
 }
 
 impl Select {
-    /// Add a number of children to a <select> tag.
+    /// Add a number of children to a `<select>` tag.
     pub fn children<I, C>(mut self, children: I) -> Self
     where
         C: Into<SelectOption>,
@@ -91,7 +91,7 @@ impl Select {
         self
     }
 
-    /// Add a single child to a <select> tag.
+    /// Add a single child to a `<select>` tag.
     pub fn child<C>(mut self, child: C) -> Self
     where
         C: Into<SelectOption>,

--- a/malvolio/src/tags/title.rs
+++ b/malvolio/src/tags/title.rs
@@ -13,7 +13,7 @@ use super::head::head_node::HeadNode;
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "pub_fields", derive(FieldsAccessibleVariant))]
 #[cfg_attr(feature = "fuzz", derive(serde::Serialize, serde::Deserialize))]
-/// The <title> tag.
+/// The `<title>` tag.
 ///
 /// See the [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title) for more
 /// info.


### PR DESCRIPTION
This fixes some occurrences in doc comments, where the html wasn't escaped which led to [crazy bugs](https://docs.rs/malvolio/0.3.1/malvolio/tags/index.html) in the html documentations :smiley: 

I might have missed some, but most of them should be corrected now.